### PR TITLE
Add Proton Authenticator to 2fa tool options

### DIFF
--- a/2fa.html
+++ b/2fa.html
@@ -48,6 +48,7 @@
                 <li><a href="https://www.microsoft.com/en-us/security/mobile-authenticator-app" target="_blank">Microsoft Authenticator</a></li>
                 <li><a href="https://support.google.com/accounts/answer/1066447" target="_blank">Google Authenticator</a></li>
                 <li><a href="https://authy.com/download" target="_blank">Authy</a></li>
+                <li><a href="https://proton.me/authenticator" target="_blank">Proton Authenticator</a></li>
             </ul>
         </div>
 


### PR DESCRIPTION
Proton Authenticator is an open source ([ios](https://github.com/protonpass/ios-authenticator), [android](https://github.com/protonpass/android-authenticator)) 2fa app from a reputable company.

Reasonably easy to use, so good option for people who want something easy to use, while also being more private than Microsoft/Google.